### PR TITLE
Update the conda recipe for Linux

### DIFF
--- a/whitebox_tools/conda.recipe/build.sh
+++ b/whitebox_tools/conda.recipe/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if [ `uname` == Linux ]; then
+    export SSL_CERT_FILE="$CONDA_PREFIX/ssl/cacert.pem"
+fi
 $PYTHON build.py
 export WHITEBOX_TOOLS_SHARE=$CONDA_PREFIX/share/whitebox_tools
 mkdir -p $WHITEBOX_TOOLS_SHARE

--- a/whitebox_tools/conda.recipe/meta.yaml
+++ b/whitebox_tools/conda.recipe/meta.yaml
@@ -14,6 +14,8 @@ requirements:
     - setuptools
     - rust
     - xarray
+    - openssl  # [linux]
+    - toolchain  # [linux]
 
   run:
     - python


### PR DESCRIPTION
This PR makes some updates to the conda.recipe directory so that a package could be built on Linux. The main changes involved adding `openssl` as a build-time dependency, with a corresponding environment variable in build.sh. `toolchain` was also added as a build-time dependency, to help with the transition to conda-forge, and to indicate that a C compiler is required.