### PR TITLE
Remove workaround to versioneer due to missing git tag

### DIFF
--- a/whitebox_tools/whitebox_tools/__init__.py
+++ b/whitebox_tools/whitebox_tools/__init__.py
@@ -1,5 +1,1 @@
-__import__('pkg_resources').declare_namespace('whitebox_tools')
-from whitebox_tools._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
 from whitebox_tools.whitebox_cli import *


### PR DESCRIPTION
This PR removes a workaround in _whitebox_tools/whitebox_tools/__init__.py_ which causes `setuptools` to become a runtime dependency. It was originally meant to get around a versioning ambiguity, due to the lack of a git tag for the repo.